### PR TITLE
chore: fix "use r" typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Allowing you to pass additional arguments for the call using currying.
 let make = () => {
   let (AsyncHook.{state: createUserState}, createUser) = AsyncHook.use((~cb, ~name, ~age) => cb(() => {
     // It accepts anything that returns a Promise.t(result('a, 'e))
-    fetch("/use r", ~params={
+    fetch("/user", ~params={
       name,
       age,
     })


### PR DESCRIPTION
This PR will fix the "use r" typo on `README`